### PR TITLE
Add output file names to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,25 @@
 all: html pdf docx rtf
 
-pdf: resume.md
+pdf: resume.pdf
+resume.pdf: resume.md
 	pandoc --standalone --template style_chmduquesne.tex \
 	--from markdown --to context \
 	-V papersize=A4 \
 	-o resume.tex resume.md; \
 	context resume.tex
 
-html: style_chmduquesne.css resume.md
+html: resume.html
+resume.html: style_chmduquesne.css resume.md
 	pandoc --standalone -H style_chmduquesne.css \
         --from markdown --to html \
         -o resume.html resume.md
 
-docx: resume.md
+docx: resume.docx
+resume.docx: resume.md
 	pandoc -s -S resume.md -o resume.docx
 
-rtf: resume.md
+rtf: resume.rtf
+resume.rtf: resume.md
 	pandoc -s -S resume.md -o resume.rtf
 
 clean:


### PR DESCRIPTION
By making output file names explicit, we can avoid rebuilding
when source is not modified.