### PR TITLE
Add Arch dependencies to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ sudo apt install pandoc context
 ```bash
 sudo dnf install pandoc texlive-collection-context
 ```
+
+#### Arch
+```bash
+sudo pacman -S pandoc texlive-core
+```


### PR DESCRIPTION
Add instructions for installing dependencies on Arch Linux and derivatives.

On Arch, the [`texlive-most`] group depends on most TeX Live related packages, [`texlive-core`] appears to be the bare minimum install for ConTeXt.

See the [Arch Wiki article] on TeX Live for details.

[Arch Wiki article]: https://wiki.archlinux.org/index.php/TeX_Live
[`texlive-core`]: https://www.archlinux.org/packages/extra/any/texlive-core/
[`texlive-most`]: https://www.archlinux.org/groups/x86_64/texlive-most/