### PR TITLE
Fixed pdf Makefile dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: html pdf docx rtf
 
 pdf: resume.pdf
-resume.pdf: resume.md
+resume.pdf: style_chmduquesne.tex resume.md
 	pandoc --standalone --template style_chmduquesne.tex \
 	--from markdown --to context \
 	-V papersize=A4 \


### PR DESCRIPTION
The pdf target in the Makefile didn't list `style_chmduquesne.tex` as a dependency, even though it is one. This makes make properly detect when the theme file has been modified, and regenerates the pdf accordingly. 