### PR TITLE
Corrected path to makefile in dockerfile

### DIFF
--- a/.docker/resume.dockerfile
+++ b/.docker/resume.dockerfile
@@ -14,7 +14,7 @@ ENV APP_NAME=resume
 # before switching to user we need to set permission properly
 # copy all files, except the ignored files from .dockerignore
 COPY . $HOME/$APP_NAME/
-COPY ./.docker/Makefile $HOME/$APP_NAME/
+COPY ./Makefile $HOME/$APP_NAME/
 RUN chown -R app:app $HOME/*
 
 USER app


### PR DESCRIPTION
The existing dockerfile references to the incorrect location (in `.docker`) for the makefile which appears to have been moved to the project root directory.  This PR fixes that so that the Docker Compose instructions work correctly.