### PR TITLE
Make the width flexible by setting max-width

### DIFF
--- a/style_chmduquesne.css
+++ b/style_chmduquesne.css
@@ -11,7 +11,7 @@
 /* Whole document */
 body {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    width: 800px;
+    max-width: 800px;
     margin: auto;
     background: #FFFFFF;
     padding: 10px 10px 10px 10px;


### PR DESCRIPTION
https://github.com/mszep/pandoc_resume/issues/31 Make the default resume mobile friendly

