### PR TITLE
Add OSX install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ sudo dnf install pandoc texlive-collection-context
 sudo pacman -S pandoc texlive-core
 ```
 
+#### OSX
+```bash
+brew install pandoc
+mkdir $HOME/context
+cd $HOME/context
+rsync -av rsync://contextgarden.net/minimals/setup/first-setup.sh .
+sh ./first-setup.sh --modules=all --engine=luatex
+```
+
 ### Troubleshooting
 Some users have reported problems where their system does not properly find the ConTeXt
 executable, leading to errors like `Cannot find context.lua` or similar. It has been found


### PR DESCRIPTION
I've tested the instructions on Sierra and I was able to generate all the correct file types

Sources
* http://brewformulas.org/Pandoc
* http://wiki.contextgarden.net/Mac_Installation

Unfortunately, context is not in homebrew yet
