### PR TITLE
Added lua script from pandoc discussion to convert links to new tab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ html: init
 		FILE_NAME=`basename $$f | sed 's/.md//g'`; \
 		echo $$FILE_NAME.html; \
 		pandoc --standalone --include-in-header $(STYLES_DIR)/$(STYLE).css \
+			--lua-filter=pdc-links-target-blank.lua \
 			--from markdown --to html \
 			--output $(OUT_DIR)/$$FILE_NAME.html $$f; \
 	done

--- a/pdc-links-target-blank.lua
+++ b/pdc-links-target-blank.lua
@@ -1,0 +1,15 @@
+-- Add target="_blank" attributes to all http links in a Pandoc document
+
+local function add_target_blank (link)
+    if string.match(link.target, '^http') then  -- here .target == href attribute
+        link.attributes.target = '_blank'       -- here .target == traget attribute
+    end
+    return link
+end
+
+-- remove lines 4 and 6 to add target="_blank" to all links, not just http(s)
+
+return {
+    { Link = add_target_blank }
+}
+


### PR DESCRIPTION
This lua script should convert all links to `target="_blank"` to default links to open in a new tab in the html output https://github.com/mszep/pandoc_resume/issues/41.

Thanks to BP Jonsson on the [pandoc discussion thread](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/pandoc-discuss/F5uolkngyQI/NjhUmqsXCAAJ). I did not know you can combine the power of lua and pandoc!