### PR TITLE
Fix Makefile to ensure the pdf output goes to the output directory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ pdf: init
 			--from markdown --to context \
 			--variable papersize=A4 \
 			--output $(OUT_DIR)/$$FILE_NAME.tex $$f > /dev/null; \
-		context $(OUT_DIR)/$$FILE_NAME.tex \
-			--result=$(OUT_DIR)/$$FILE_NAME.pdf > $(OUT_DIR)/context_$$FILE_NAME.log 2>&1; \
+		mtxrun --path=$(OUT_DIR) --result=$$FILE_NAME.pdf --script context $$FILE_NAME.tex > $(OUT_DIR)/context_$$FILE_NAME.log 2>&1; \
 	done
 
 html: init


### PR DESCRIPTION
This addresses issue #50.

I have only tested on Mac with the latest pandoc and context from Homebrew, versions in the above issue.