### PR TITLE
amended makefile to include metadata element of pagetitle on resume html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ html: init
 		pandoc --standalone --include-in-header $(STYLES_DIR)/$(STYLE).css \
 			--lua-filter=pdc-links-target-blank.lua \
 			--from markdown --to html \
-			--output $(OUT_DIR)/$$FILE_NAME.html $$f; \
+			--output $(OUT_DIR)/$$FILE_NAME.html $$f \
+			--metadata pagetitle=$$FILE_NAME;\
 	done
 
 docx: init


### PR DESCRIPTION
per #53 , this commit just simply appends to the metadata of a generated html a pagetitle equal to file name. Prevents output warning regarding lack of a <title> specification.

There is probably a better way to do this that respects a value specified in an input resume file, so i'd entertain making some edits to enable that.

Love the repo though! A wonderful little tool.