### PR TITLE
Fix generation PDF on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ pdf: init
 			--from markdown --to context \
 			--variable papersize=A4 \
 			--output $(OUT_DIR)/$$FILE_NAME.tex $$f > /dev/null; \
+		if test -d /usr/local/texlive/2020/texmf-dist/scripts; then export TEXMF='/usr/local/texlive/2020/texmf-dist/scripts'; fi; \
 		mtxrun --path=$(OUT_DIR) --result=$$FILE_NAME.pdf --script context $$FILE_NAME.tex > $(OUT_DIR)/context_$$FILE_NAME.log 2>&1; \
 	done
 


### PR DESCRIPTION
Problem with PDF generation on macos was in TEXMF env variable.

before:
```shell
$ make pdf
mkdir -p output
PANDOC_VERSION=`pandoc --version | head -1 | cut -d' ' -f2 | cut -d'.' -f1`; \
	if [ "$PANDOC_VERSION" -eq "2" ]; then \
		SMART=-smart; \
	else \
		SMART=--smart; \
	fi \

for f in markdown/*.md; do \
		FILE_NAME=`basename $f | sed 's/.md//g'`; \
		echo $FILE_NAME.pdf; \
		pandoc --standalone --template styles/chmduquesne.tex \
			--from markdown --to context \
			--variable papersize=A4 \
			--output output/$FILE_NAME.tex $f > /dev/null; \
		mtxrun --path=output --result=$FILE_NAME.pdf --script context $FILE_NAME.tex > output/context_$FILE_NAME.log 2>&1; \
	done
resume.pdf
make: *** [pdf] Error 1
```

after
```shell 
$ make pdf
mkdir -p output
PANDOC_VERSION=`pandoc --version | head -1 | cut -d' ' -f2 | cut -d'.' -f1`; \
	if [ "$PANDOC_VERSION" -eq "2" ]; then \
		SMART=-smart; \
	else \
		SMART=--smart; \
	fi \

for f in markdown/*.md; do \
		FILE_NAME=`basename $f | sed 's/.md//g'`; \
		echo $FILE_NAME.pdf; \
		pandoc --standalone --template styles/chmduquesne.tex \
			--from markdown --to context \
			--variable papersize=A4 \
			--output output/$FILE_NAME.tex $f > /dev/null; \
		if test -d /usr/local/texlive/2020/texmf-dist/scripts; then export TEXMF='/usr/local/texlive/2020/texmf-dist/scripts'; fi; \
		mtxrun --path=output --result=$FILE_NAME.pdf --script context $FILE_NAME.tex > output/context_$FILE_NAME.log 2>&1; \
	done
resume.pdf
```