### PR TITLE
Add reading YAML Metadata block into PDF Metadata

### DIFF
--- a/styles/chmduquesne.tex
+++ b/styles/chmduquesne.tex
@@ -20,7 +20,13 @@ $endif$
 \definecolor[rulecolor][h=9cb770]
 
 % Enable hyperlinks
-\setupinteraction[state=start, color=sectioncolor]
+\setupinteraction[
+    state=start,
+    title=$title-meta$,
+    author=$author-meta$,
+    keyword={$for(keywords)$$keywords$$sep$, $endfor$},
+    date=$date$
+    color=sectioncolor]
 
 \setuppapersize [$if(papersize)$$papersize$$else$letter$endif$][$if(papersize)$$papersize$$else$letter$endif$]
 \setuplayout    [width=middle, height=middle,


### PR DESCRIPTION
if user provides PDF metadata variable e.g. `author-meta`, `title-meta`, and `keywords` in the YAML Metadata block of the Markdown file, it will be used as PDF Metadata.

The variable `title-meta` will be displayed on the PDF Reader instead of plain "resume" string.

MWE:
```markdown
---
author-meta: "Donald Duck"
title-meta: "Ducky Duck Duck"
keywords:
    - Duck
    - Ducky
    - Donald
...

Donald Duck
===========

Education
---------
```

YAML Metadata Block is optional.