### PR TITLE
Build with Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.swo
 *.swp
 output/
+result
+result-*
+.envrc
+.direnv

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Make sure to add the directory `/Library/TeX/texbin/` to your path or `context` 
 export PATH=$PATH:/Library/TeX/texbin/
 ```
 
+#### Nix
+
+Make sure to enable flakes, see [this](https://nixos.wiki/wiki/Flakes).
+
+```bash
+nix build
+```
+
+The built resume will end up in `./result`.
+
 ### Troubleshooting
 
 #### Get versions

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1655269044,
+        "narHash": "sha256-VscxTckDD3wSdXsJxkOrdtDo4h4nVD5GutWQmD2uMlM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "81ccb11016c0e333f6158ec6af965a47c37e5055",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  inputs = { nixpkgs.url = "github:nixos/nixpkgs"; };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = nixpkgs.lib.systems.flakeExposed;
+      perSystem = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = system: import nixpkgs { inherit system; };
+
+      buildResumeFor = system:
+        let pkgs = pkgsFor system;
+        in pkgs.runCommand "build-resume" {
+          nativeBuildInputs = with pkgs; [ pandoc texlive.combined.scheme-context ];
+        } ''
+          cd ${self}
+          make OUT_DIR="$out"
+        '';
+    in {
+      packages.resume = perSystem (system: buildResumeFor system);
+      devShell =
+        perSystem (system: import ./shell.nix { pkgs = pkgsFor system; });
+      defaultPackage = perSystem (system: self.packages.resume.${system});
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,3 @@
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+mkShell { buildInputs = [ pandoc texlive.combined.scheme-context gnumake ]; }


### PR DESCRIPTION
From [nixos.org](nixos.org):

> Nix provides developers with a complete and consistent development environment. Stop worrying how to install dependencies for your project.

With nix, we can build without installing any tools manually. The build environment also works identically across multiple os/arch.