### PR TITLE
Fix /bin/sh: mtxrun: not found (Docker on Ubuntu 20.04)

### DIFF
--- a/.docker/resume.dockerfile
+++ b/.docker/resume.dockerfile
@@ -2,4 +2,6 @@ FROM pandoc/latex:2.9
 
 RUN apk add make texlive
 
+ENV TEXMF /usr/share/texmf-dist
+
 COPY actions/entrypoint.sh /entrypoint.sh

--- a/.docker/resume.dockerfile
+++ b/.docker/resume.dockerfile
@@ -1,5 +1,5 @@
 FROM pandoc/latex:2.9
 
-RUN apk add make
+RUN apk add make texlive
 
 COPY actions/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Fixes #83