### PR TITLE
flake.nix: remove unsupported systems from `supportedSystems` list

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,21 @@
 
   outputs = { self, nixpkgs }:
     let
-      supportedSystems = nixpkgs.lib.systems.flakeExposed;
+      supportedSystems =
+        let
+          unsupportedSystems = [
+            # GHC not supported
+            "armv5tel-linux"
+            "armv6l-linux"
+            "powerpc64le-linux"
+            "riscv64-linux"
+
+            # "error: attribute 'busybox' missing" when building
+            # `bootstrap-tools`
+            "mipsel-linux"
+          ];
+        in nixpkgs.lib.subtractLists unsupportedSystems nixpkgs.lib.systems.flakeExposed;
+
       perSystem = nixpkgs.lib.genAttrs supportedSystems;
       pkgsFor = system: import nixpkgs { inherit system; };
 


### PR DESCRIPTION
Most of the unsupported systems are unsupported because the transitive dependency GHC is not available; `mipsel-linux` is unsupported because of an issue building Nix's bootstrap tools.

This corrects some sources of fatal errors when running `nix flake check` against this project.

Thanks in advance for your consideration!