### PR TITLE
flake.nix: fix outputs structure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,13 +30,21 @@
           make OUT_DIR="$out"
         '';
     in {
-      packages = perSystem (system: {
-        resume = buildResumeFor system;
+      packages = perSystem (system:
+        let
+          resume = buildResumeFor system;
+        in
+        {
+          inherit resume;
+          default = resume;
+        });
+
+      devShells = perSystem (system: {
+        default = import ./shell.nix { pkgs = pkgsFor system; };
       });
 
-      devShell =
-        perSystem (system: import ./shell.nix { pkgs = pkgsFor system; });
+      devShell = perSystem (system: self.devShells.${system}.default);
 
-      defaultPackage = perSystem (system: self.packages.${system}.resume);
+      defaultPackage = perSystem (system: self.packages.${system}.default);
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -30,9 +30,13 @@
           make OUT_DIR="$out"
         '';
     in {
-      packages.resume = perSystem (system: buildResumeFor system);
+      packages = perSystem (system: {
+        resume = buildResumeFor system;
+      });
+
       devShell =
         perSystem (system: import ./shell.nix { pkgs = pkgsFor system; });
-      defaultPackage = perSystem (system: self.packages.resume.${system});
+
+      defaultPackage = perSystem (system: self.packages.${system}.resume);
     };
 }


### PR DESCRIPTION
Marked as a draft because this branch is based on #88.

This PR introduces two changes:

### Swap the `resume` and `system` attribute nesting order

In current `master`, the Nix derivation representing the built resume lives under the flake output attribute `packages.resume.<system>`.  `nix flake check` does not like this, complaining `error: 'resume' is not a valid system type`.  I have swapped the nesting such that the built resume now lives at `packages.<system>.resume`.

### Upstream flake output schema changes

The Nix flake output schema changed somewhat recently; now, rather than `defaultPackage.<system>` and `devShell.<system>`, flakes are expected to expose `packages.<system>.default` and `devShells.<system>.default`.  I have updated this flake's outputs to reflect these changes, while also aliasing `defaultPackage.<system>` to `packages.<system>.default` and aliasing `devShell.<system>` to `devShells.<system>.default` for backward compatibility.