### PR TITLE
flake.nix: add overlay that exposes a resume-building function

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,76 @@ nix build
 
 The built resume will end up in `./result`.
 
+Additionally, this project's flake overlay output exposes the function
+`pandocResume.buildResume` for building a resume stored somewhere other than
+[the default location](#instructions):
+
+```nix
+{
+  description = "Flake for building my resume";
+
+  inputs = { pandoc_resume.url = "github:mszep/pandoc_resume"; };
+
+  outputs = { self, nixpkgs, pandoc_resume }:
+    {
+      packages.x86_64-linux =
+        let
+          pkgs = import nixpkgs { system = "x86_64-linux"; overlays = [ pandoc_resume.overlays.pandocResume ]; };
+
+          myResume = pkgs.pandocResume.buildResume {
+            # Mandatory.
+            #
+            # Must specify a directory containing a resume whose basename
+            # includes the extension `.md`.
+            inDir = "${self}/my-resume";
+
+            # Optional.
+            #
+            # The specified directory must contain the files `<style>.css` and
+            # `<style>.tex` for each supported style `<style>`.
+            #
+            # Defaults to "${pandoc_resume}/styles".
+            stylesDir = "${self}/my-styles";
+
+            # Optional.
+            #
+            # Given "my-style", `stylesDir` must contain `my-style.css` and
+            # `my-style.tex`.
+            #
+            # Defaults to "chmduquesne".
+            style = "my-style";
+          };
+        in
+        {
+          inherit myResume;
+          default = myResume;
+        };
+    };
+}
+```
+
+In the example above, you can build your resume by running the following from
+your flake's top-level directory (assuming you are on an `x86_64-linux`
+system):
+
+```
+nix build
+```
+
+Or, equivalently:
+
+```
+nix build '.#myResume'
+```
+
+Or via any valid [flake reference](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-references).
+For instance, if the flake containing your resume is hosted at
+`https://my.git.host/my-flake`, you can build it with:
+
+```
+nix build 'git+https://my.git.host/my-flake#myResume'
+```
+
 ### Troubleshooting
 
 #### Get versions

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,8 @@
     in {
       packages = perSystem (system:
         let
-          resume = buildResumeFor system;
+          pkgs = pkgsFor system;
+          resume = pkgs.pandocResume.buildResume { inDir = "${self}/markdown"; };
         in
         {
           inherit resume;

--- a/flake.nix
+++ b/flake.nix
@@ -18,18 +18,43 @@
           ];
         in nixpkgs.lib.subtractLists unsupportedSystems nixpkgs.lib.systems.flakeExposed;
 
-      perSystem = nixpkgs.lib.genAttrs supportedSystems;
-      pkgsFor = system: import nixpkgs { inherit system; };
+      overlay = final: prev: {
+        pandocResume.buildResume =
+          {
+            inDir
+          , stylesDir ? null
+          , style ? null
+          }@args: let
+            overrides = prev.lib.filterAttrs (_: value: value != null) args;
 
-      buildResumeFor = system:
-        let pkgs = pkgsFor system;
-        in pkgs.runCommand "build-resume" {
-          nativeBuildInputs = with pkgs; [ pandoc texlive.combined.scheme-context ];
-        } ''
-          cd ${self}
-          make OUT_DIR="$out"
-        '';
+            arg2env = {
+              inDir = "IN_DIR";
+              stylesDir = "STYLES_DIR";
+              style = "STYLE";
+            };
+
+            env =
+              let
+                quoteIfNecessary = value: if builtins.isPath value then value else prev.lib.escapeShellArg value;
+                assign = name: "${arg2env.${name}}=${quoteIfNecessary overrides.${name}}";
+              in builtins.foldl' (a: name: a ++ [ (assign name) ]) [] (builtins.attrNames overrides);
+
+          in final.runCommand "build-resume" {
+            nativeBuildInputs = with final; [ pandoc texlive.combined.scheme-context ];
+          } ''
+            cd ${self}
+            make OUT_DIR="$out" ${toString env}
+          '';
+      };
+
+      perSystem = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = system: import nixpkgs { inherit system; overlays = [ self.overlays.default ]; };
     in {
+      overlays = {
+        pandocResume = overlay;
+        default = overlay;
+      };
+
       packages = perSystem (system:
         let
           pkgs = pkgsFor system;


### PR DESCRIPTION
Marked this PR as a draft because it depends on #89.

This PR adds a Nix flake overlay output that defines the function `pandocResume.buildResume`.  The idea is to allow users to store their resumes and any associated assets in a location of their choosing, and build their resume with the same Nix code as is used to build the resume stored in this project.

Idea for further improvement: add a [Nix flake template](https://peppe.rs/posts/novice_nix:_flake_templates/) that generates a Nix flake along the lines of the example flake demonstrated in the `README.md` changes.