### PR TITLE
fix: docker-compose.yml warning due to obsolete `version` attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
 
   resume-make:


### PR DESCRIPTION
Fixes this issue:

`WARN[0000] /home/########/dev/pandoc_resume/docker-compose.yml: the attribute 'version' is obsolete, it will be ignored, please remove it to avoid potential confusion`